### PR TITLE
Correctly process PolyChord seed

### DIFF
--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -148,7 +148,7 @@ class polychord(Sampler):
         settings: Any = load_module('pypolychord.settings', path=self._poly_build_path,
                                     min_version=None)
         self.pc_settings = settings.PolyChordSettings(
-            self.nDims, self.nDerived, seed=(self.seed if self.seed is not None else -1),
+            self.nDims, self.nDerived,
             **{p: getattr(self, p) for p in pc_args if getattr(self, p) is not None})
         # Prepare callback function
         if self.callback_function is not None:

--- a/cobaya/samplers/polychord/polychord.py
+++ b/cobaya/samplers/polychord/polychord.py
@@ -142,13 +142,13 @@ class polychord(Sampler):
                    "cluster_posteriors", "write_resume", "read_resume",
                    "write_stats", "write_live", "write_dead", "write_prior",
                    "maximise", "compression_factor", "synchronous", "base_dir",
-                   "file_root", "seed", "grade_dims", "grade_frac", "nlives"]
+                   "file_root", "grade_dims", "grade_frac", "nlives"]
         # As stated above, num_repeats is ignored, so let's not pass it
         pc_args.pop(pc_args.index("num_repeats"))
         settings: Any = load_module('pypolychord.settings', path=self._poly_build_path,
                                     min_version=None)
         self.pc_settings = settings.PolyChordSettings(
-            self.nDims, self.nDerived,
+            self.nDims, self.nDerived, seed=(self.seed if self.seed is not None else -1),
             **{p: getattr(self, p) for p in pc_args if getattr(self, p) is not None})
         # Prepare callback function
         if self.callback_function is not None:

--- a/cobaya/samplers/polychord/polychord.yaml
+++ b/cobaya/samplers/polychord/polychord.yaml
@@ -73,7 +73,7 @@ blocking:
 confidence_for_unbounded: 0.9999995  # 5 sigmas of the prior
 # Seeding runs
 # ------------
-seed:  # positive integer
+seed: -1 # positive integer
 # Raw output of PolyChord (no need to change them, normally)
 # ----------------------------------------------------------
 file_root:

--- a/cobaya/samplers/polychord/polychord.yaml
+++ b/cobaya/samplers/polychord/polychord.yaml
@@ -73,7 +73,7 @@ blocking:
 confidence_for_unbounded: 0.9999995  # 5 sigmas of the prior
 # Seeding runs
 # ------------
-seed: -1 # positive integer
+seed:  # positive integer
 # Raw output of PolyChord (no need to change them, normally)
 # ----------------------------------------------------------
 file_root:


### PR DESCRIPTION
The seed polychord argumentt is included both in pc_args and separately, so the constructor of `PolyChordSettings` receives it twice.